### PR TITLE
Adds support of geo 4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Envelope.Mixfile do
 
   defp deps() do
     [
-      {:geo, "~> 1.0 or ~> 2.0 or ~> 3.0"},
+      {:geo, "~> 1.0 or ~> 2.0 or ~> 3.0 or ~> 4.0"},
       {:distance, "~> 0.2.1 or ~> 1.0"},
       {:excoveralls, "~> 0.4", only: :test},
       {:earmark, "~> 1.0", only: :dev},


### PR DESCRIPTION
The changes add support for `4.0` version of https://github.com/felt/geo

Tests are passing in this project and in https://github.com/pkinney/topo with forced geo `4.0`

If you are happy with the changes, I'll update https://github.com/pkinney/topo next 🙇 